### PR TITLE
fix: resolve state, caching, and ui bugs across clients and products

### DIFF
--- a/ferredesk_v0/backend/ferreapps/clientes/tests.py
+++ b/ferredesk_v0/backend/ferreapps/clientes/tests.py
@@ -1,3 +1,82 @@
-from django.test import TestCase
+from django_tenants.test.cases import TenantTestCase
+from django_tenants.test.client import TenantClient
+from django.db.models import Max
 
-# Create your tests here.
+from ferreapps.clientes.models import Cliente, Provincia, TipoIVA
+from tenants.models import EmpresaTenant
+from tenants.services import inicializar_datos_tenant
+
+
+class ClienteViewSetAPITestCase(TenantTestCase):
+    @classmethod
+    def setup_tenant(cls, tenant):
+        tenant.nombre = "Tenant Clientes Test"
+        tenant.slug_subdominio = "tenant-clientes-test"
+        tenant.email_admin = "admin@clientes.test"
+        tenant.estado_suscripcion = EmpresaTenant.ESTADO_SUSCRIPCION_ACTIVO
+
+    @classmethod
+    def get_test_schema_name(cls):
+        return "testclientesapi"
+
+    @classmethod
+    def get_test_tenant_domain(cls):
+        return "testclientesapi.lvh.me"
+
+    def setUp(self):
+        super().setUp()
+
+        inicializar_datos_tenant(
+            tenant=self.tenant,
+            email="admin@clientes.test",
+            password="testpass123",
+        )
+
+        self.client = TenantClient(self.tenant)
+        self.assertTrue(self.client.login(username="admin@clientes.test", password="testpass123"))
+
+        self.tipo_iva = TipoIVA.objects.order_by("id").first()
+        self.provincia_a = Provincia.objects.create(nombre="Buenos Aires", activo="S")
+        self.provincia_b = Provincia.objects.create(nombre="Cordoba", activo="S")
+        max_cliente_id = Cliente.objects.aggregate(max_id=Max("id"))["max_id"] or 0
+
+        self.cliente_objetivo = Cliente.objects.create(
+            id=max_cliente_id + 1,
+            razon="Ferreteria Central",
+            fantasia="Central",
+            domicilio="Calle 123",
+            tel1="111111",
+            email="central@test.local",
+            cuit="20999888776",
+            iva=self.tipo_iva,
+            provincia=self.provincia_a,
+            activo="A",
+        )
+        Cliente.objects.create(
+            id=max_cliente_id + 2,
+            razon="Corralon Norte",
+            fantasia="Norte",
+            domicilio="Otra 456",
+            tel1="222222",
+            email="norte@test.local",
+            cuit="20999888775",
+            iva=self.tipo_iva,
+            provincia=self.provincia_b,
+            activo="A",
+        )
+
+    def test_clientes_search_busca_por_email_y_telefono(self):
+        response = self.client.get("/api/clientes/clientes/?search=central@test.local")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"][0]["id"], self.cliente_objetivo.id)
+
+    def test_clientes_filtra_por_provincia(self):
+        response = self.client.get(f"/api/clientes/clientes/?provincia={self.provincia_a.id}")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["results"][0]["id"], self.cliente_objetivo.id)

--- a/ferredesk_v0/backend/ferreapps/clientes/views.py
+++ b/ferredesk_v0/backend/ferreapps/clientes/views.py
@@ -17,6 +17,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from ferreapps.productos.utils.paginacion import PaginacionPorPaginaConLimite
 from django.db.models import Q, ProtectedError
 from .algoritmo_cuit_utils import validar_cuit
+from django.db.models.functions import Lower
 
 # Create your views here.
 logger = logging.getLogger('ferredesk_arca.procesar_cuit_arca')
@@ -89,7 +90,20 @@ class ClienteViewSet(viewsets.ModelViewSet):
         Retorna el queryset base optimizado, aplicando búsqueda si se proporciona el parámetro 'search'.
         """
         # Queryset base excluyendo el cliente por defecto (id=1)
-        queryset = Cliente.objects.exclude(id=1).select_related('iva')
+        queryset = (
+            Cliente.objects
+            .exclude(id=1)
+            .select_related(
+                'iva',
+                'barrio',
+                'localidad',
+                'provincia',
+                'transporte',
+                'vendedor',
+                'plazo',
+                'categoria',
+            )
+        )
         
         # Filtro opcional: solo clientes con movimientos en la tabla VENTA
         if self.request.query_params.get('con_ventas') == '1':
@@ -98,7 +112,7 @@ class ClienteViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(id__in=ids_con_ventas)
         
         # Parámetro de búsqueda de texto libre
-        termino_busqueda = self.request.query_params.get('search', '')
+        termino_busqueda = (self.request.query_params.get('search', '') or '').strip()
         
         if termino_busqueda:
             # Búsqueda en múltiples campos usando Q objects
@@ -107,31 +121,36 @@ class ClienteViewSet(viewsets.ModelViewSet):
                 Q(fantasia__icontains=termino_busqueda) |
                 Q(cuit__icontains=termino_busqueda) |
                 Q(domicilio__icontains=termino_busqueda) |
-                Q(iva__nombre__icontains=termino_busqueda)
+                Q(iva__nombre__icontains=termino_busqueda) |
+                Q(tel1__icontains=termino_busqueda) |
+                Q(tel2__icontains=termino_busqueda) |
+                Q(tel3__icontains=termino_busqueda) |
+                Q(email__icontains=termino_busqueda)
             ).distinct()
+
+        provincia_id = self.request.query_params.get('provincia')
+        localidad_id = self.request.query_params.get('localidad')
+        condicion_iva = self.request.query_params.get('condicion_iva') or self.request.query_params.get('iva')
+
+        if provincia_id:
+            queryset = queryset.filter(provincia_id=provincia_id)
+        if localidad_id:
+            queryset = queryset.filter(localidad_id=localidad_id)
+        if condicion_iva:
+            queryset = queryset.filter(iva_id=condicion_iva)
         
         # Ordenamiento
         orden = self.request.query_params.get('orden', 'id')
         direccion = self.request.query_params.get('direccion', 'desc')
 
-        if orden == 'id':
-            if direccion == 'asc':
-                queryset = queryset.order_by('id')
-            else:
-                queryset = queryset.order_by('-id')
-        elif orden == 'razon':
-            if direccion == 'asc':
-                queryset = queryset.order_by('razon')
-            else:
-                queryset = queryset.order_by('-razon')
+        if orden == 'razon':
+            queryset = queryset.order_by(Lower('razon').asc(), 'id') if direccion == 'asc' else queryset.order_by(Lower('razon').desc(), '-id')
         elif orden == 'fantasia':
-            if direccion == 'asc':
-                queryset = queryset.order_by('fantasia')
-            else:
-                queryset = queryset.order_by('-fantasia')
+            queryset = queryset.order_by(Lower('fantasia').asc(nulls_last=True), 'id') if direccion == 'asc' else queryset.order_by(Lower('fantasia').desc(nulls_last=True), '-id')
+        elif orden == 'cuit':
+            queryset = queryset.order_by('cuit', 'id') if direccion == 'asc' else queryset.order_by('-cuit', '-id')
         else:
-            # Ordenamiento por defecto: más recientes primero
-            queryset = queryset.order_by('-id')
+            queryset = queryset.order_by('id') if direccion == 'asc' else queryset.order_by('-id')
         
         return queryset
 

--- a/ferredesk_v0/backend/ferreapps/informes/tests.py
+++ b/ferredesk_v0/backend/ferreapps/informes/tests.py
@@ -1,3 +1,117 @@
-from django.test import TestCase
+from datetime import date
+from decimal import Decimal
 
-# Create your tests here.
+from django.db.models import Max
+from django_tenants.test.cases import TenantTestCase
+from django_tenants.test.client import TenantClient
+
+from ferreapps.productos.models import AlicuotaIVA, Proveedor, Stock, StockProve
+from tenants.models import EmpresaTenant
+from tenants.services import inicializar_datos_tenant
+
+
+class StockBajoAPITestCase(TenantTestCase):
+    @classmethod
+    def setup_tenant(cls, tenant):
+        tenant.nombre = "Tenant Informes Test"
+        tenant.slug_subdominio = "tenant-informes-test"
+        tenant.email_admin = "admin@informes.test"
+        tenant.estado_suscripcion = EmpresaTenant.ESTADO_SUSCRIPCION_ACTIVO
+
+    @classmethod
+    def get_test_schema_name(cls):
+        return "testinformesapi"
+
+    @classmethod
+    def get_test_tenant_domain(cls):
+        return "testinformesapi.lvh.me"
+
+    def setUp(self):
+        super().setUp()
+
+        inicializar_datos_tenant(
+            tenant=self.tenant,
+            email="admin@informes.test",
+            password="testpass123",
+        )
+
+        self.client = TenantClient(self.tenant)
+        self.assertTrue(self.client.login(username="admin@informes.test", password="testpass123"))
+
+        self.proveedor = Proveedor.objects.create(
+            razon="Proveedor Informe",
+            fantasia="Proveedor Informe",
+            domicilio="Calle 123",
+            cuit="20999123456",
+            impsalcta=Decimal("0.00"),
+            fecsalcta=date.today(),
+            sigla="INF",
+            acti="S",
+        )
+        self.alicuota = AlicuotaIVA.objects.order_by("id").first()
+        if self.alicuota is None:
+            max_id = AlicuotaIVA.objects.aggregate(max_id=Max("id"))["max_id"] or 0
+            self.alicuota = AlicuotaIVA.objects.create(
+                id=max_id + 1,
+                codigo="21",
+                deno="IVA 21%",
+                porce=Decimal("21.00"),
+            )
+
+        max_stock_id = Stock.objects.aggregate(max_id=Max("id"))["max_id"] or 0
+        self.producto_bajo = Stock.objects.create(
+            id=max_stock_id + 1,
+            codvta="INF001",
+            deno="Pinza de corte",
+            unidad="UN",
+            margen=Decimal("20.00"),
+            cantmin=Decimal("5.00"),
+            idaliiva=self.alicuota,
+            proveedor_habitual=self.proveedor,
+            acti="S",
+            precio_lista_0=Decimal("1000.00"),
+            precio_lista_0_manual=False,
+        )
+        StockProve.objects.create(
+            stock=self.producto_bajo,
+            proveedor=self.proveedor,
+            cantidad=Decimal("1.00"),
+            costo=Decimal("600.00"),
+        )
+
+        self.producto_con_stock = Stock.objects.create(
+            id=max_stock_id + 2,
+            codvta="INF002",
+            deno="Taladro",
+            unidad="UN",
+            margen=Decimal("20.00"),
+            cantmin=Decimal("2.00"),
+            idaliiva=self.alicuota,
+            proveedor_habitual=self.proveedor,
+            acti="S",
+            precio_lista_0=Decimal("1000.00"),
+            precio_lista_0_manual=False,
+        )
+        StockProve.objects.create(
+            stock=self.producto_con_stock,
+            proveedor=self.proveedor,
+            cantidad=Decimal("10.00"),
+            costo=Decimal("600.00"),
+        )
+
+    def test_stock_bajo_lista_devuelve_resultados_paginados_y_filtrados(self):
+        response = self.client.get("/api/informes/stock-bajo/?search=pinza&limit=10")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(len(payload["results"]), 1)
+        self.assertEqual(payload["results"][0]["codigo_venta"], "INF001")
+
+    def test_stock_bajo_pdf_respeta_filtros_activos(self):
+        response = self.client.get("/api/informes/stock-bajo/pdf/?search=pinza")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertIn("attachment; filename=", response["Content-Disposition"])
+        self.assertGreater(len(response.content), 0)

--- a/ferredesk_v0/backend/ferreapps/informes/views.py
+++ b/ferredesk_v0/backend/ferreapps/informes/views.py
@@ -11,55 +11,119 @@ from reportlab.lib import colors
 from io import BytesIO
 from django.utils import timezone
 from ferreapps.productos.models import Stock
+from django.db.models import Q, F
+from django.db.models.functions import Lower
+from rest_framework.permissions import IsAuthenticated
+from ferreapps.productos.utils.paginacion import PaginacionPorPaginaConLimite
 
 # Create your views here.
 
-class StockBajoView(APIView):
-    """Vista para obtener datos de productos con stock bajo"""
-    
+def _es_true(valor):
+    return str(valor).strip().lower() in {"1", "true", "t", "si", "sí", "yes", "y"}
+
+
+class _StockBajoBaseAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def _get_queryset(self, request):
+        queryset = (
+            Stock.objects
+            .con_stock_total()
+            .select_related('proveedor_habitual', 'idfam1', 'idfam2', 'idfam3')
+            .filter(necesita_reposicion=1)
+        )
+
+        search = (request.query_params.get('search') or '').strip()
+        proveedor_id = request.query_params.get('proveedor') or request.query_params.get('proveedor_habitual')
+        familia_id = request.query_params.get('familia')
+        idfam1 = request.query_params.get('idfam1')
+        idfam2 = request.query_params.get('idfam2')
+        idfam3 = request.query_params.get('idfam3')
+        acti = request.query_params.get('acti')
+
+        if search:
+            queryset = queryset.filter(
+                Q(codvta__icontains=search) |
+                Q(deno__icontains=search) |
+                Q(codigo_barras__icontains=search) |
+                Q(proveedor_habitual__razon__icontains=search) |
+                Q(proveedor_habitual__fantasia__icontains=search)
+            ).distinct()
+
+        if proveedor_id:
+            queryset = queryset.filter(proveedor_habitual_id=proveedor_id)
+        if familia_id:
+            queryset = queryset.filter(Q(idfam1_id=familia_id) | Q(idfam2_id=familia_id) | Q(idfam3_id=familia_id))
+        if idfam1:
+            queryset = queryset.filter(idfam1_id=idfam1)
+        if idfam2:
+            queryset = queryset.filter(idfam2_id=idfam2)
+        if idfam3:
+            queryset = queryset.filter(idfam3_id=idfam3)
+        if acti:
+            queryset = queryset.filter(acti=acti)
+
+        if _es_true(request.query_params.get('solo_sin_stock')):
+            queryset = queryset.filter(stock_total__lte=0)
+        elif not _es_true(request.query_params.get('solo_bajo_minimo', '1')):
+            queryset = queryset.filter(stock_total__gte=0)
+
+        orden = request.query_params.get('orden', 'denominacion')
+        direccion = request.query_params.get('direccion', 'asc')
+
+        if orden == 'codigo_venta':
+            queryset = queryset.order_by(Lower('codvta').asc(), 'id') if direccion == 'asc' else queryset.order_by(Lower('codvta').desc(), '-id')
+        elif orden == 'stock_total':
+            queryset = queryset.order_by('stock_total', 'id') if direccion == 'asc' else queryset.order_by('-stock_total', '-id')
+        elif orden == 'diferencia':
+            queryset = queryset.annotate(diferencia_reposicion=F('cantmin') - F('stock_total'))
+            queryset = queryset.order_by('diferencia_reposicion', 'id') if direccion == 'asc' else queryset.order_by('-diferencia_reposicion', '-id')
+        else:
+            queryset = queryset.order_by(Lower('deno').asc(), 'id') if direccion == 'asc' else queryset.order_by(Lower('deno').desc(), '-id')
+
+        return queryset
+
+    def _serializar_producto(self, producto):
+        stock_total = float(producto.stock_total or 0)
+        cantidad_minima = float(producto.cantidad_minima or 0)
+        return {
+            'id': producto.id,
+            'denominacion': producto.denominacion,
+            'codigo_venta': producto.codigo_venta,
+            'cantidad_minima': cantidad_minima,
+            'stock_total': stock_total,
+            'necesita_reposicion': producto.necesita_reposicion,
+            'diferencia': cantidad_minima - stock_total,
+            'proveedor_razon': producto.proveedor_razon or '',
+            'proveedor_fantasia': producto.proveedor_fantasia or '',
+        }
+
+
+class StockBajoView(_StockBajoBaseAPIView):
+    """Vista para obtener datos paginados de productos con stock bajo."""
+
+    pagination_class = PaginacionPorPaginaConLimite
+
     def get(self, request):
         try:
-            # Obtener productos con stock bajo usando el manager anotado
-            productos_stock_bajo = Stock.objects.con_stock_total().filter(
-                necesita_reposicion=1
-            ).order_by('denominacion')
-            
-            # Convertir a lista de diccionarios para la respuesta
-            datos = []
-            for producto in productos_stock_bajo:
-                            datos.append({
-                'id': producto.id,
-                'denominacion': producto.denominacion,
-                'codigo_venta': producto.codigo_venta,
-                'cantidad_minima': producto.cantidad_minima or 0,
-                'stock_total': float(producto.stock_total),
-                'necesita_reposicion': producto.necesita_reposicion,
-                'diferencia': (producto.cantidad_minima or 0) - float(producto.stock_total),
-                'proveedor_razon': producto.proveedor_razon or '',
-                'proveedor_fantasia': producto.proveedor_fantasia or ''
-            })
-            
-            return Response({
-                'status': 'success',
-                'data': datos,
-                'total_productos': len(datos)
-            })
-            
+            queryset = self._get_queryset(request)
+            paginator = self.pagination_class()
+            page = paginator.paginate_queryset(queryset, request, view=self)
+            datos = [self._serializar_producto(producto) for producto in page]
+            return paginator.get_paginated_response(datos)
         except Exception as e:
             return Response({
                 'status': 'error',
                 'message': f'Error al obtener datos: {str(e)}'
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-class StockBajoPDFView(APIView):
-    """Vista para generar PDF del informe de stock bajo"""
+
+class StockBajoPDFView(_StockBajoBaseAPIView):
+    """Vista para generar PDF del informe de stock bajo según filtros activos."""
     
     def get(self, request):
         try:
-            # Obtener productos con stock bajo usando el manager anotado
-            productos_stock_bajo = Stock.objects.con_stock_total().filter(
-                necesita_reposicion=1
-            ).order_by('denominacion')
+            productos_stock_bajo = list(self._get_queryset(request))
             
            
             buffer = BytesIO() #reserva un espacio en memoria pal pdf
@@ -98,7 +162,7 @@ class StockBajoPDFView(APIView):
             if productos_stock_bajo:
                
                 PRODUCTOS_POR_PAGINA = 30  
-                productos_lista = list(productos_stock_bajo)
+                productos_lista = productos_stock_bajo
                 
                 # Dividir productos en páginas
                 for i in range(0, len(productos_lista), PRODUCTOS_POR_PAGINA):

--- a/ferredesk_v0/backend/ferreapps/productos/views.py
+++ b/ferredesk_v0/backend/ferreapps/productos/views.py
@@ -187,28 +187,32 @@ class StockViewSet(viewsets.ModelViewSet):
         # Si no se especifica 'acti' en los parámetros, filtrar por activos por defecto
         if 'acti' not in self.request.query_params:
             queryset = queryset.filter(acti='S')
+
+        tipo_codigo = (self.request.query_params.get('tipo_codigo') or '').strip().lower()
+        if tipo_codigo in {'con_codigo_interno', 'interno'}:
+            queryset = queryset.filter(
+                codigo_barras__isnull=False,
+                tipo_codigo_barras__in=['EAN13', 'CODE128'],
+            ).exclude(codigo_barras='')
+        elif tipo_codigo in {'con_codigo_externo', 'externo'}:
+            queryset = queryset.filter(
+                codigo_barras__isnull=False,
+                tipo_codigo_barras='EXTERNO',
+            ).exclude(codigo_barras='')
+        elif tipo_codigo in {'sin_codigo', 'sin_codigo_barras'}:
+            queryset = queryset.filter(Q(codigo_barras__isnull=True) | Q(codigo_barras=''))
         
         # Ordenamiento
         orden = self.request.query_params.get('orden', 'id')
         direccion = self.request.query_params.get('direccion', 'desc')
         
         if orden == 'id':
-            if direccion == 'asc':
-                queryset = queryset.order_by('id')
-            else:
-                queryset = queryset.order_by('-id')
+            queryset = queryset.order_by('id') if direccion == 'asc' else queryset.order_by('-id')
         elif orden == 'deno':
-            if direccion == 'asc':
-                queryset = queryset.order_by('deno')
-            else:
-                queryset = queryset.order_by('-deno')
+            queryset = queryset.order_by(Lower('deno').asc(), 'id') if direccion == 'asc' else queryset.order_by(Lower('deno').desc(), '-id')
         elif orden == 'codvta':
-            if direccion == 'asc':
-                queryset = queryset.order_by('codvta')
-            else:
-                queryset = queryset.order_by('-codvta')
+            queryset = queryset.order_by(Lower('codvta').asc(), 'id') if direccion == 'asc' else queryset.order_by(Lower('codvta').desc(), '-id')
         else:
-            # Ordenamiento por defecto: más recientes primero
             queryset = queryset.order_by('-id')
         
         return queryset
@@ -472,10 +476,26 @@ class PosProductoSearchAPIView(APIView):
 # Atomicidad para las relaciones entre productos y proveedores
 @method_decorator(transaction.atomic, name='dispatch')
 class StockProveViewSet(viewsets.ModelViewSet):
-    queryset = StockProve.objects.all()
+    queryset = StockProve.objects.select_related('proveedor', 'stock').all()
     serializer_class = StockProveSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ['stock', 'proveedor']
+    pagination_class = PaginacionPorPaginaConLimite
+
+    def get_queryset(self):
+        queryset = super().get_queryset().select_related('proveedor', 'stock')
+        stock_id = self.request.query_params.get('stock')
+        proveedor_id = self.request.query_params.get('proveedor')
+
+        if stock_id:
+            queryset = queryset.filter(stock_id=stock_id)
+        if proveedor_id:
+            queryset = queryset.filter(proveedor_id=proveedor_id)
+
+        if getattr(self, 'action', None) == 'list' and not stock_id and not proveedor_id:
+            return queryset.none()
+
+        return queryset.order_by('-id')
 
 class FamiliaFilter(FilterSet):
     """
@@ -507,7 +527,8 @@ class FamiliaFilter(FilterSet):
 
 # cache_page de 12hs: Familias y Alícuotas son datos maestros que rara vez cambian.
 # Se aplica solo a 'list' para no interferir con create/update/delete.
-@method_decorator(cache_page(60 * 60 * 12), name='list')
+# DESACTIVADO: Causaba que el modal de Familias no se actualice en tiempo real tras crear/editar.
+# @method_decorator(cache_page(60 * 60 * 12), name='list')
 class FamiliaViewSet(viewsets.ModelViewSet):
     queryset = Familia.objects.all()
     serializer_class = FamiliaSerializer

--- a/ferredesk_v0/frontend/src/components/Clientes/ClienteForm.js
+++ b/ferredesk_v0/frontend/src/components/Clientes/ClienteForm.js
@@ -223,16 +223,35 @@ const ClienteForm = ({
   const [modalForm, setModalForm] = useState({})
   const [modalLoading, setModalLoading] = useState(false)
 
+  useEffect(() => {
+    let cancelled = false
+
+    const cargarCatalogoSiFalta = async (listaActual, setLista, url, mensajeError) => {
+      if (!Array.isArray(listaActual) || listaActual.length > 0 || typeof setLista !== "function") return
+      try {
+        const res = await fetch(url, { credentials: "include" })
+        if (!res.ok) throw new Error(mensajeError)
+        const data = await res.json()
+        if (!cancelled) {
+          setLista(Array.isArray(data) ? data : data.results || [])
+        }
+      } catch (_) { }
+    }
+
+    cargarCatalogoSiFalta(barrios, setBarrios, "/api/clientes/barrios/", "Error al obtener barrios")
+    cargarCatalogoSiFalta(localidades, setLocalidades, "/api/clientes/localidades/", "Error al obtener localidades")
+
+    return () => {
+      cancelled = true
+    }
+  }, [barrios, localidades, setBarrios, setLocalidades])
+
   // Hook para el tema de FerreDesk
   const theme = useFerreDeskTheme()
 
   // Ref para conocer el CUIT actual dentro de efectos sin agregar dependencias
   const cuitActualRef = useRef(form.cuit)
   useEffect(() => { cuitActualRef.current = form.cuit }, [form.cuit])
-
-  // Constante para determinar si estamos en modo PRODUCCION
-  const MODO_PRODUCCION = 'PROD'
-  const esModoProduccion = ferreteria?.modo_arca === MODO_PRODUCCION
 
   // Helper: lista solo activos pero conservando la opción seleccionada aunque esté inactiva
   const filtrarActivosConSeleccion = useCallback((lista, seleccionadoId) => {
@@ -561,7 +580,7 @@ const ClienteForm = ({
       })
       if (!res.ok) throw new Error("Error al crear")
       // Refrescar la lista
-      const data = await fetch(url).then((r) => r.json())
+      const data = await fetch(url, { credentials: "include" }).then((r) => r.json())
       setList(Array.isArray(data) ? data : data.results || [])
       closeModal()
     } catch (err) {

--- a/ferredesk_v0/frontend/src/components/Clientes/ClientesManager.js
+++ b/ferredesk_v0/frontend/src/components/Clientes/ClientesManager.js
@@ -22,6 +22,7 @@ import { useSessionUserQuery } from "../../domains/session/useSessionUserQuery"
 
 // Hook del tema de FerreDesk
 import { useFerreDeskTheme } from "../../hooks/useFerreDeskTheme"
+import { leerConsultaPersistida, guardarConsultaPersistida } from "../../utils/consultaPersistida"
 
 // Contenedor principal de gestión de clientes
 const ClientesManager = () => {
@@ -45,8 +46,10 @@ const ClientesManager = () => {
   }, [error, clearError])
 
   // Búsqueda
-  const [search, setSearch] = useState("")
-  const [searchInactivos, setSearchInactivos] = useState("")
+  const [search, setSearch] = useState(() => leerConsultaPersistida("clientes_search", ""))
+  const [searchInactivos, setSearchInactivos] = useState(() => leerConsultaPersistida("clientes_search_inactivos", ""))
+  const [appliedSearch, setAppliedSearch] = useState(() => leerConsultaPersistida("clientes_search", ""))
+  const [appliedSearchInactivos, setAppliedSearchInactivos] = useState(() => leerConsultaPersistida("clientes_search_inactivos", ""))
 
   // ---------- Tabs tipo navegador ----------
   const [tabs, setTabs] = useState(() => {
@@ -85,6 +88,33 @@ const ClientesManager = () => {
     const savedActiveTab = localStorage.getItem("clientesActiveTab")
     return savedActiveTab === "maestros" ? "lista" : (savedActiveTab || "lista")
   })
+
+  const handleBuscarClientes = useCallback(() => {
+    if (activeTab === "lista") {
+      if (!search || search.trim() === "") return
+      setAppliedSearch(search)
+      guardarConsultaPersistida("clientes_search", search)
+      setPagina(1)
+    } else if (activeTab === "inactivos") {
+      if (!searchInactivos || searchInactivos.trim() === "") return
+      setAppliedSearchInactivos(searchInactivos)
+      guardarConsultaPersistida("clientes_search_inactivos", searchInactivos)
+      setPagina(1)
+    }
+  }, [activeTab, search, searchInactivos])
+
+  const handleLimpiarClientes = useCallback(() => {
+    setPagina(1)
+    if (activeTab === "lista") {
+      setSearch("")
+      setAppliedSearch("")
+      guardarConsultaPersistida("clientes_search", "")
+    } else if (activeTab === "inactivos") {
+      setSearchInactivos("")
+      setAppliedSearchInactivos("")
+      guardarConsultaPersistida("clientes_search_inactivos", "")
+    }
+  }, [activeTab])
 
 
   const [expandedClientId, setExpandedClientId] = useState(null)
@@ -156,8 +186,15 @@ const ClientesManager = () => {
   }
 
   // Filtrado de clientes activos e inactivos con useMemo para optimización
-  const clientesActivos = React.useMemo(() => clientes, [clientes])
-  const clientesInactivos = React.useMemo(() => clientes, [clientes])
+  const clientesActivos = React.useMemo(() => {
+    if (!appliedSearch || appliedSearch.trim() === "") return []
+    return clientes
+  }, [clientes, appliedSearch])
+  
+  const clientesInactivos = React.useMemo(() => {
+    if (!appliedSearchInactivos || appliedSearchInactivos.trim() === "") return []
+    return clientes
+  }, [clientes, appliedSearchInactivos])
 
   // ---------- Hooks de entidades relacionales ----------
   const { barrios, setBarrios } = useBarriosAPI()
@@ -181,24 +218,25 @@ const ClientesManager = () => {
   // ------------------------------------------------------------------
   // Efecto: cada vez que cambia búsqueda o pestaña, pedimos al backend con activo=A/I
   useEffect(() => {
-    const termino = activeTab === "inactivos" ? searchInactivos : search
+    const termino = activeTab === "inactivos" ? appliedSearchInactivos : appliedSearch
+    if (!termino || termino.trim() === "") return // Evitar fetch si no hay termino
+    
     const timeout = setTimeout(() => {
       const filtros = {}
       if (termino && termino.trim() !== "") {
-        filtros.razon__icontains = termino.trim()
-        filtros.fantasia__icontains = termino.trim()
+        filtros.search = termino.trim()
       }
       if (activeTab === "lista") filtros.activo = "A"
       if (activeTab === "inactivos") filtros.activo = "I"
       fetchClientes(filtros, pagina, itemsPorPagina, 'id', ordenamiento)
     }, 300)
     return () => clearTimeout(timeout)
-  }, [search, searchInactivos, activeTab, pagina, itemsPorPagina, ordenamiento, fetchClientes])
+  }, [appliedSearch, appliedSearchInactivos, activeTab, pagina, itemsPorPagina, ordenamiento, fetchClientes])
 
   // Resetear a página 1 cuando cambian pestaña o términos de búsqueda correspondientes
   useEffect(() => { setPagina(1) }, [activeTab])
-  useEffect(() => { if (activeTab === "lista") setPagina(1) }, [search, activeTab])
-  useEffect(() => { if (activeTab === "inactivos") setPagina(1) }, [searchInactivos, activeTab])
+  useEffect(() => { if (activeTab === "lista") setPagina(1) }, [appliedSearch, activeTab])
+  useEffect(() => { if (activeTab === "inactivos") setPagina(1) }, [appliedSearchInactivos, activeTab])
 
   // Eliminar cualquier renderizado visual de error relacionado a 'error' en la UI
 
@@ -290,6 +328,8 @@ const ClientesManager = () => {
                     onOrdenamientoChange={handleOrdenamientoChange}
                     ordenamientoControlado={ordenamiento === 'asc'}
                     cargando={loading}
+                    onBuscar={handleBuscarClientes}
+                    onLimpiar={handleLimpiarClientes}
                   />
                 )}
 

--- a/ferredesk_v0/frontend/src/components/Clientes/ClientesTable.js
+++ b/ferredesk_v0/frontend/src/components/Clientes/ClientesTable.js
@@ -34,6 +34,9 @@ const ClientesTable = ({
   onOrdenamientoChange = null,
   ordenamientoControlado = null,
   cargando = false,
+  consultaEjecutada = false,
+  onBuscar = null,
+  onLimpiar = null,
 }) => {
   // Función para generar los botones de acciones para clientes
   const generarBotonesCliente = (cliente) => {
@@ -246,13 +249,13 @@ const ClientesTable = ({
                         <div className="flex justify-between">
                           <span className="text-slate-500">Zona:</span>
                           <span className="font-medium text-slate-700">
-                            {barrios.find((b) => String(b.id) === String(cli.barrio))?.nombre || "N/A"}
+                            {barrios.find((b) => String(b.id) === String(cli.barrio))?.nombre || cli.barrio || "N/A"}
                           </span>
                         </div>
                         <div className="flex justify-between">
                           <span className="text-slate-500">Localidad:</span>
                           <span className="font-medium text-slate-700">
-                            {localidades.find((l) => String(l.id) === String(cli.localidad))?.nombre || "N/A"}
+                            {localidades.find((l) => String(l.id) === String(cli.localidad))?.nombre || cli.localidad || "N/A"}
                           </span>
                         </div>
                         <div className="flex justify-between">
@@ -344,9 +347,11 @@ const ClientesTable = ({
   // Filtrado de clientes para pasarlo a Tabla (la búsqueda global la gestiona Tabla)
   // Tabla no filtra por visibilidad de datos nulos; podemos replicar anterior
   // ---------------------------------------------------------------------------
-  const clientesFiltrados = (clientes || []).filter(
-    (cli) => cli && ((cli.razon ? cli.razon.toLowerCase() : "").includes(search.toLowerCase()) || (cli.fantasia ? cli.fantasia.toLowerCase() : "").includes(search.toLowerCase())),
-  )
+  const clientesFiltrados = busquedaRemota
+    ? (clientes || [])
+    : (clientes || []).filter(
+      (cli) => cli && ((cli.razon ? cli.razon.toLowerCase() : "").includes(search.toLowerCase()) || (cli.fantasia ? cli.fantasia.toLowerCase() : "").includes(search.toLowerCase())),
+    )
 
   return (
     <Tabla
@@ -354,6 +359,8 @@ const ClientesTable = ({
       datos={clientesFiltrados}
       valorBusqueda={search}
       onCambioBusqueda={setSearch}
+      onBuscar={onBuscar}
+      onLimpiar={onLimpiar}
       filasPorPaginaInicial={10}
       paginacionControlada={paginacionControlada}
       paginaActual={paginaActual}
@@ -366,6 +373,8 @@ const ClientesTable = ({
       ordenamientoControlado={ordenamientoControlado}
       renderFila={renderFila}
       cargando={cargando}
+      mensajeVacio={consultaEjecutada ? "No hay datos para mostrar." : "No hay datos para mostrar"}
+      subtituloVacio={consultaEjecutada ? "" : "Ajustá los filtros."}
     />
   )
 }

--- a/ferredesk_v0/frontend/src/components/Informes/StockBajoList.js
+++ b/ferredesk_v0/frontend/src/components/Informes/StockBajoList.js
@@ -5,28 +5,81 @@ import RefreshOutlinedIcon from '@mui/icons-material/RefreshOutlined';
 import { useStockBajoAPI } from '../../utils/useStockBajoAPI';
 import Tabla from '../Tabla';
 import { useFerreDeskTheme } from "../../hooks/useFerreDeskTheme";
+import { guardarConsultaPersistida, leerConsultaPersistida, limpiarConsultaPersistida } from "../../utils/consultaPersistida";
 
 const StockBajoList = () => {
+  const estadoPersistido = leerConsultaPersistida("stockBajoConsultaPersistida", {});
   const theme = useFerreDeskTheme();
-  const { productos, loading, error, totalProductos, obtenerProductosStockBajo, generarPDF } = useStockBajoAPI();
+  const { productos, loading, error, totalProductos, obtenerProductosStockBajo, generarPDF, limpiarResultados } = useStockBajoAPI();
   const [generandoPDF, setGenerandoPDF] = useState(false);
-  const [searchTerm, setSearchTerm] = useState("");
+  const [searchTerm, setSearchTerm] = useState(() => estadoPersistido.searchTerm || "");
+  const [consultaEjecutada, setConsultaEjecutada] = useState(() => estadoPersistido.consultaEjecutada || false);
+  const [filtroAplicado, setFiltroAplicado] = useState(() => estadoPersistido.filtroAplicado || "");
+  const [pagina, setPagina] = useState(() => estadoPersistido.pagina || 1);
+  const [itemsPorPagina, setItemsPorPagina] = useState(() => estadoPersistido.itemsPorPagina || 20);
+  const [ordenamiento, setOrdenamiento] = useState(() => estadoPersistido.ordenamiento || "asc");
 
   useEffect(() => {
     document.title = "Informe Stock Bajo - FerreDesk";
   }, []);
 
+  useEffect(() => {
+    guardarConsultaPersistida("stockBajoConsultaPersistida", {
+      searchTerm,
+      consultaEjecutada,
+      filtroAplicado,
+      pagina,
+      itemsPorPagina,
+      ordenamiento,
+    });
+  }, [searchTerm, consultaEjecutada, filtroAplicado, pagina, itemsPorPagina, ordenamiento]);
+
+  useEffect(() => {
+    if (consultaEjecutada) {
+      obtenerProductosStockBajo({
+        search: filtroAplicado,
+        page: pagina,
+        limit: itemsPorPagina,
+        orden: "denominacion",
+        direccion: ordenamiento,
+      });
+    }
+  }, [consultaEjecutada, filtroAplicado, pagina, itemsPorPagina, ordenamiento, obtenerProductosStockBajo]);
+
   const handleGenerarPDF = async () => {
     setGenerandoPDF(true);
     try {
-      await generarPDF();
+      await generarPDF({
+        search: filtroAplicado,
+        orden: "denominacion",
+        direccion: ordenamiento,
+      });
     } finally {
       setGenerandoPDF(false);
     }
   };
 
   const handleRefresh = () => {
-    obtenerProductosStockBajo();
+    setPagina(1);
+    setFiltroAplicado(searchTerm.trim());
+    setConsultaEjecutada(true);
+  };
+
+  const handleEjecutarInforme = () => {
+    setPagina(1);
+    setFiltroAplicado(searchTerm.trim());
+    setConsultaEjecutada(true);
+  };
+
+  const handleLimpiarInforme = () => {
+    setSearchTerm("");
+    setConsultaEjecutada(false);
+    setFiltroAplicado("");
+    setPagina(1);
+    setItemsPorPagina(20);
+    setOrdenamiento("asc");
+    limpiarResultados();
+    limpiarConsultaPersistida("stockBajoConsultaPersistida");
   };
 
   const columnas = [
@@ -68,6 +121,29 @@ const StockBajoList = () => {
 
   return (
     <div className="flex flex-col gap-4">
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <p className="text-sm font-semibold text-slate-800">Consulta de stock bajo</p>
+            <p className="text-xs text-slate-500">Ejecutá el informe manualmente para evitar cargas automáticas innecesarias.</p>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={handleEjecutarInforme}
+              className={theme.botonPrimario + " !py-2 !h-auto text-xs"}
+            >
+              Ejecutar informe
+            </button>
+            <button
+              onClick={handleLimpiarInforme}
+              className="px-3 py-2 bg-white border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 transition-all duration-200 font-semibold text-xs shadow-sm"
+            >
+              Limpiar
+            </button>
+          </div>
+        </div>
+      </div>
+
       {/* Mini Header / Actions */}
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-3 bg-slate-50 border border-slate-200 py-2 px-4 rounded-xl">
@@ -83,7 +159,7 @@ const StockBajoList = () => {
         <div className="flex gap-2">
           <button
             onClick={handleRefresh}
-            disabled={loading}
+            disabled={loading || !consultaEjecutada}
             className="px-3 py-2 bg-white border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 transition-all duration-200 font-semibold flex items-center gap-2 text-xs shadow-sm disabled:opacity-50"
           >
             <RefreshOutlinedIcon className="w-4 h-4" />
@@ -92,7 +168,7 @@ const StockBajoList = () => {
 
           <button
             onClick={handleGenerarPDF}
-            disabled={generandoPDF || loading || productos.length === 0}
+            disabled={generandoPDF || loading || productos.length === 0 || !consultaEjecutada}
             className={theme.botonPrimario + " !py-2 !h-auto flex items-center gap-2 text-xs"}
           >
             <PictureAsPdfOutlinedIcon className="w-4 h-4" />
@@ -113,19 +189,33 @@ const StockBajoList = () => {
       <div className="w-full">
         <Tabla
           columnas={columnas}
-          datos={productos}
-          cargando={loading}
+          datos={consultaEjecutada ? productos : []}
+          cargando={consultaEjecutada ? loading : false}
           valorBusqueda={searchTerm}
           onCambioBusqueda={setSearchTerm}
           filasPorPaginaInicial={20}
           mostrarOrdenamiento={true}
           tamañoEncabezado="pequeño"
           filasCompactas={true}
+          paginacionControlada={true}
+          paginaActual={pagina}
+          onPageChange={setPagina}
+          itemsPerPage={itemsPorPagina}
+          onItemsPerPageChange={setItemsPorPagina}
+          totalRemoto={totalProductos}
+          busquedaRemota={true}
+          onOrdenamientoChange={(ascendente) => {
+            setOrdenamiento(ascendente ? "asc" : "desc")
+            setPagina(1)
+          }}
+          ordenamientoControlado={ordenamiento === "asc"}
+          mensajeVacio={consultaEjecutada ? "No se encontraron resultados" : "Informe sin ejecutar"}
+          subtituloVacio={consultaEjecutada ? "" : "Presioná Ejecutar informe para consultar stock bajo."}
         />
       </div>
 
       {/* Footer Minimalista */}
-      {!loading && productos.length > 0 && (
+      {!loading && consultaEjecutada && productos.length > 0 && (
         <div className="flex justify-end pr-2">
           <span className="text-[10px] text-slate-400 font-medium italic">
             Sincronizado: {new Date().toLocaleTimeString('es-AR')}

--- a/ferredesk_v0/frontend/src/components/Presupuestos y Ventas/herramientasforms/AccionesMenu.js
+++ b/ferredesk_v0/frontend/src/components/Presupuestos y Ventas/herramientasforms/AccionesMenu.js
@@ -58,14 +58,14 @@ const AccionesMenu = ({
               const ComponenteBoton = boton.componente
               return (
                 <div key={index} className="group">
-                  <button
+                  <div
                     onClick={(e) => {
+                      if (boton.disabled) return;
                       e.stopPropagation()
                       boton.onClick()
                       triggerProps.onClick(e) // Cierra el tooltip después de la acción
                     }}
-                    disabled={boton.disabled}
-                    className="w-full flex items-center gap-2.5 px-2.5 py-1.5 bg-slate-50/50 hover:bg-slate-100/80 transition-all duration-200 border border-transparent hover:border-slate-200/50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className={`w-full flex items-center gap-2.5 px-2.5 py-1.5 bg-slate-50/50 transition-all duration-200 border border-transparent cursor-pointer ${boton.disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-slate-100/80 hover:border-slate-200/50'}`}
                     title={boton.titulo}
                   >
                     <div className="flex-shrink-0 w-3.5 h-3.5 flex items-center justify-center">
@@ -92,7 +92,7 @@ const AccionesMenu = ({
                     <span className="text-xs text-slate-700 font-medium text-left leading-tight">
                       {boton.titulo}
                     </span>
-                  </button>
+                  </div>
 
                   {/* Separador sutil entre elementos */}
                   {index < botones.length - 1 && (

--- a/ferredesk_v0/frontend/src/components/Productos/BotonAccionesProductos.js
+++ b/ferredesk_v0/frontend/src/components/Productos/BotonAccionesProductos.js
@@ -1,0 +1,86 @@
+"use client"
+
+import React, { useState, useRef, useEffect } from "react"
+import { useFerreDeskTheme } from "../../hooks/useFerreDeskTheme"
+import { Plus, FolderTree, RefreshCw, ChevronDown } from "lucide-react"
+
+const BotonAccionesProductos = ({ onNuevoProducto, onGestionarFamilias, onActualizarListas }) => {
+  const theme = useFerreDeskTheme()
+  const [visible, setVisible] = useState(false)
+  const dropdownRef = useRef(null)
+
+  // Cerrar dropdown al hacer click fuera
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setVisible(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [])
+
+  const opciones = [
+    {
+      id: "nuevo_producto",
+      label: "Nuevo Producto",
+      icon: <Plus className="w-4 h-4" />,
+      onClick: onNuevoProducto,
+    },
+    {
+      id: "gestionar_familias",
+      label: "Gestionar Familias",
+      icon: <FolderTree className="w-4 h-4" />,
+      onClick: onGestionarFamilias,
+    },
+    {
+      id: "actualizar_listas",
+      label: "Actualizar Listas",
+      icon: <RefreshCw className="w-4 h-4" />,
+      onClick: onActualizarListas,
+    },
+  ]
+
+  return (
+    <div className="relative inline-block text-left" ref={dropdownRef}>
+      {/* Botón principal */}
+      <button
+        onClick={() => setVisible(!visible)}
+        type="button"
+        className={`${theme.botonPrimario} flex items-center gap-1.5 text-xs px-3 py-1 h-8`}
+      >
+        <Plus className="w-3 h-3" />
+        <span>Acciones</span>
+        <ChevronDown
+          className={`w-3 h-3 transition-transform duration-200 ${visible ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {/* Dropdown */}
+      {visible && (
+        <div className="absolute right-0 mt-1.5 w-48 bg-white rounded-lg shadow-lg border border-slate-200 z-50 py-1" role="menu">
+          {opciones.map((opcion) => (
+            <button
+              key={opcion.id}
+              type="button"
+              onClick={() => {
+                opcion.onClick()
+                setVisible(false)
+              }}
+              className="w-full px-3 py-2 text-left hover:bg-orange-500 hover:text-white flex items-center space-x-2 text-slate-700 transition-colors duration-150 group text-xs font-medium"
+            >
+              <div className="text-slate-400 group-hover:text-white transition-colors">
+                {opcion.icon}
+              </div>
+              <span>{opcion.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default BotonAccionesProductos

--- a/ferredesk_v0/frontend/src/components/Productos/FamiliasModal.js
+++ b/ferredesk_v0/frontend/src/components/Productos/FamiliasModal.js
@@ -14,14 +14,22 @@ function FamiliasModal({ open, onClose, familias, addFamilia, updateFamilia, del
 
   const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value })
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!form.deno) return alert("El nombre es obligatorio")
     if (!form.nivel) return alert("El nivel es obligatorio")
+    
+    let result;
     if (editId) {
-      updateFamilia(editId, form)
+      result = await updateFamilia(editId, form)
     } else {
-      addFamilia(form)
+      result = await addFamilia(form)
     }
+    
+    if (result && result.error) {
+      alert(result.error)
+      return
+    }
+
     setForm({ deno: "", comentario: "", nivel: "", acti: "S" })
     setEditId(null)
   }

--- a/ferredesk_v0/frontend/src/components/Productos/FiltrosProductos.js
+++ b/ferredesk_v0/frontend/src/components/Productos/FiltrosProductos.js
@@ -1,0 +1,124 @@
+"use client"
+
+import React from "react"
+import BotonAccionesProductos from "./BotonAccionesProductos"
+
+const FiltrosProductos = ({
+  familias = [],
+  fam1Filtro,
+  setFam1Filtro,
+  fam2Filtro,
+  setFam2Filtro,
+  fam3Filtro,
+  setFam3Filtro,
+  buscarPorCodigoProveedor,
+  setBuscarPorCodigoProveedor,
+  setSearchProductos,
+  onNuevoProducto,
+  onGestionarFamilias,
+  onActualizarListas,
+}) => {
+  const CLASES_ETIQUETA = "text-[10px] uppercase tracking-wide text-slate-500 font-semibold"
+  const CLASES_INPUT = "w-full border border-slate-300 rounded-lg px-2 py-1 text-xs h-8 focus:ring-2 focus:ring-orange-500/40 focus:border-orange-500 bg-white transition-all duration-200"
+  const CLASES_FILTRO = "bg-white border border-slate-200/60 rounded-xl p-2.5 h-16 flex flex-col justify-between shadow-sm"
+
+  return (
+    <div className="flex items-start gap-3 w-full mb-4 flex-wrap sm:flex-nowrap">
+      {/* Familia */}
+      <div className={`${CLASES_FILTRO} flex-1 min-w-[120px]`}>
+        <div className={CLASES_ETIQUETA}>Familia</div>
+        <div className="mt-0.5">
+          <select
+            value={fam1Filtro}
+            onChange={(e) => setFam1Filtro(e.target.value)}
+            className={CLASES_INPUT}
+          >
+            <option value="">Todas</option>
+            {familias
+              .filter((f) => f.nivel === "1")
+              .map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.deno}
+                </option>
+              ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Subfamilia */}
+      <div className={`${CLASES_FILTRO} flex-1 min-w-[120px]`}>
+        <div className={CLASES_ETIQUETA}>Subfamilia</div>
+        <div className="mt-0.5">
+          <select
+            value={fam2Filtro}
+            onChange={(e) => setFam2Filtro(e.target.value)}
+            className={CLASES_INPUT}
+          >
+            <option value="">Todas</option>
+            {familias
+              .filter((f) => f.nivel === "2")
+              .map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.deno}
+                </option>
+              ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Sub-subfamilia */}
+      <div className={`${CLASES_FILTRO} flex-1 min-w-[120px]`}>
+        <div className={CLASES_ETIQUETA}>Sub-sub</div>
+        <div className="mt-0.5">
+          <select
+            value={fam3Filtro}
+            onChange={(e) => setFam3Filtro(e.target.value)}
+            className={CLASES_INPUT}
+          >
+            <option value="">Todas</option>
+            {familias
+              .filter((f) => f.nivel === "3")
+              .map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.deno}
+                </option>
+              ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Modo de Búsqueda */}
+      <div className={`${CLASES_FILTRO} flex-1 justify-center items-start min-w-[150px]`}>
+        <div className={CLASES_ETIQUETA}>Modo de Búsqueda</div>
+        <div className="mt-1 flex items-center h-8">
+          <label className="flex items-center gap-1.5 text-xs text-slate-600 cursor-pointer select-none hover:text-orange-600 transition-colors">
+            <input
+              type="checkbox"
+              checked={buscarPorCodigoProveedor}
+              onChange={(e) => {
+                setBuscarPorCodigoProveedor(e.target.checked)
+                setSearchProductos("") // Limpiar búsqueda al cambiar modo para evitar resultados cruzados
+              }}
+              className="rounded border-slate-300 text-orange-600 focus:ring-orange-500"
+            />
+            Buscar por codigo de proveedor
+          </label>
+        </div>
+      </div>
+
+      {/* Acciones */}
+      <div className={`${CLASES_FILTRO} w-36 justify-between flex-none`}>
+        <div className={CLASES_ETIQUETA}>Acciones</div>
+        <div className="mt-0.5">
+          <BotonAccionesProductos
+            onNuevoProducto={onNuevoProducto}
+            onGestionarFamilias={onGestionarFamilias}
+            onActualizarListas={onActualizarListas}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default FiltrosProductos

--- a/ferredesk_v0/frontend/src/components/Productos/ProductosManager.js
+++ b/ferredesk_v0/frontend/src/components/Productos/ProductosManager.js
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo, useCallback } from "react"
 import Navbar from "../Navbar"
 import StockForm from "./StockForm"
 import ProductosTable from "./ProductosTable"
+import FiltrosProductos from "./FiltrosProductos"
 import { useProductosAPI } from "../../utils/useProductosAPI"
 import { useFamiliasAPI } from "../../utils/useFamiliasAPI"
 import { useProveedoresAPI } from "../../utils/useProveedoresAPI"
@@ -21,6 +22,7 @@ import { ImprimirEtiquetasModal } from "./codigoBarras"
 
 // Hook del tema de FerreDesk
 import { useFerreDeskTheme } from "../../hooks/useFerreDeskTheme"
+import { leerConsultaPersistida, guardarConsultaPersistida } from "../../utils/consultaPersistida"
 
 const ProductosManager = () => {
   // Hook del tema de FerreDesk
@@ -89,7 +91,22 @@ const ProductosManager = () => {
   const { logout } = useLogoutMutation()
 
   // Estado de búsqueda para ProductosTable
-  const [searchProductos, setSearchProductos] = useState("")
+  const [searchProductos, setSearchProductos] = useState(() => leerConsultaPersistida("productos_search", ""))
+  const [searchVal, setSearchVal] = useState(() => leerConsultaPersistida("productos_search", ""))
+
+  const handleBuscarProductos = useCallback(() => {
+    if (!searchVal || searchVal.trim() === "") return
+    setSearchProductos(searchVal)
+    guardarConsultaPersistida("productos_search", searchVal)
+    setPagina(1)
+  }, [searchVal])
+
+  const handleLimpiarBusquedaProductos = useCallback(() => {
+    setSearchVal("")
+    setSearchProductos("")
+    guardarConsultaPersistida("productos_search", "")
+    setPagina(1)
+  }, [])
 
   // Estado de paginación
   const [pagina, setPagina] = useState(1)
@@ -254,26 +271,29 @@ const ProductosManager = () => {
     '/api/productos/stock/',
     filtrosProductos,
     pagina,
-    itemsPorPagina
+    itemsPorPagina,
+    { enabled: !!(searchProductos && searchProductos.trim() !== "") }
   )
 
   // Filtrar productos activos/inactivos con memo para rendimiento
   // Si el campo acti no está presente, mostrar todos los productos como activos
   const productosActivosBase = useMemo(() => {
+    if (!searchProductos || searchProductos.trim() === "") return []
     if (productos.length > 0 && productos[0].acti === undefined) {
       // Si el campo acti no está presente, mostrar todos los productos
       return productos
     }
     return productos.filter((p) => p.acti === "S")
-  }, [productos])
+  }, [productos, searchProductos])
 
   const productosInactivosBase = useMemo(() => {
+    if (!searchProductos || searchProductos.trim() === "") return []
     if (productos.length > 0 && productos[0].acti === undefined) {
       // Si el campo acti no está presente, no mostrar productos inactivos
       return []
     }
     return productos.filter((p) => p.acti === "N")
-  }, [productos])
+  }, [productos, searchProductos])
 
   const aplicaFiltrosFamilia = useCallback((prod) => {
     const fam1 = prod.idfam1 && typeof prod.idfam1 === "object" ? prod.idfam1.id : prod.idfam1
@@ -351,28 +371,23 @@ const ProductosManager = () => {
               </div>
 
               <div className="flex-1 p-6">
-                {/* Botones de acción solo en la tab de lista */}
-                {activeTab === "lista" && (
-                  <div className="mb-4 flex gap-2">
-                    <button
-                      onClick={() => openTab(`nuevo-${Date.now()}`, "Nuevo Producto")}
-                      className={theme.botonPrimario}
-                    >
-                      <span className="text-lg">+</span> Nuevo Producto
-                    </button>
-                    <button
-                      onClick={() => setShowFamiliasModal(true)}
-                      className={theme.botonPrimario}
-                    >
-                      Gestionar Familias
-                    </button>
-                    <button
-                      onClick={() => setShowListasPrecioModal(true)}
-                      className={theme.botonPrimario}
-                    >
-                      Actualizar Listas
-                    </button>
-                  </div>
+                {/* Filtros y acciones para las tabs de lista y inactivos */}
+                {(activeTab === "lista" || activeTab === "inactivos") && (
+                  <FiltrosProductos
+                    familias={familias}
+                    fam1Filtro={fam1Filtro}
+                    setFam1Filtro={setFam1Filtro}
+                    fam2Filtro={fam2Filtro}
+                    setFam2Filtro={setFam2Filtro}
+                    fam3Filtro={fam3Filtro}
+                    setFam3Filtro={setFam3Filtro}
+                    buscarPorCodigoProveedor={buscarPorCodigoProveedor}
+                    setBuscarPorCodigoProveedor={setBuscarPorCodigoProveedor}
+                    setSearchProductos={setSearchVal}
+                    onNuevoProducto={() => openTab(`nuevo-${Date.now()}`, "Nuevo Producto")}
+                    onGestionarFamilias={() => setShowFamiliasModal(true)}
+                    onActualizarListas={() => setShowListasPrecioModal(true)}
+                  />
                 )}
                 {/* Contenido de pestañas */}
                 {activeTab === "lista" && (
@@ -383,12 +398,6 @@ const ProductosManager = () => {
                     setProveedores={addProveedor}
                     expandedId={expandedId}
                     setExpandedId={setExpandedId}
-                    fam1Filtro={fam1Filtro}
-                    setFam1Filtro={setFam1Filtro}
-                    fam2Filtro={fam2Filtro}
-                    setFam2Filtro={setFam2Filtro}
-                    fam3Filtro={fam3Filtro}
-                    setFam3Filtro={setFam3Filtro}
                     addFamilia={addFamilia}
                     updateFamilia={updateFamilia}
                     deleteFamilia={deleteFamilia}
@@ -399,10 +408,11 @@ const ProductosManager = () => {
                     onEdit={handleEditProducto}
                     onImprimirCodigoBarras={setProductoParaImprimirEtiquetas}
                     onUpdateStock={handleUpdateStock}
-                    searchProductos={searchProductos}
-                    setSearchProductos={setSearchProductos}
+                    searchProductos={searchVal}
+                    setSearchProductos={setSearchVal}
                     buscarPorCodigoProveedor={buscarPorCodigoProveedor}
-                    setBuscarPorCodigoProveedor={setBuscarPorCodigoProveedor}
+                    onBuscar={handleBuscarProductos}
+                    onLimpiar={handleLimpiarBusquedaProductos}
                     paginacionControlada={true}
                     paginaActual={pagina}
                     onPageChange={setPagina}
@@ -423,12 +433,6 @@ const ProductosManager = () => {
                     setProveedores={addProveedor}
                     expandedId={expandedId}
                     setExpandedId={setExpandedId}
-                    fam1Filtro={fam1Filtro}
-                    setFam1Filtro={setFam1Filtro}
-                    fam2Filtro={fam2Filtro}
-                    setFam2Filtro={setFam2Filtro}
-                    fam3Filtro={fam3Filtro}
-                    setFam3Filtro={setFam3Filtro}
                     addFamilia={addFamilia}
                     updateFamilia={updateFamilia}
                     deleteFamilia={deleteFamilia}
@@ -439,10 +443,11 @@ const ProductosManager = () => {
                     onEdit={handleEditProducto}
                     onImprimirCodigoBarras={setProductoParaImprimirEtiquetas}
                     onUpdateStock={handleUpdateStock}
-                    searchProductos={searchProductos}
-                    setSearchProductos={setSearchProductos}
+                    searchProductos={searchVal}
+                    setSearchProductos={setSearchVal}
                     buscarPorCodigoProveedor={buscarPorCodigoProveedor}
-                    setBuscarPorCodigoProveedor={setBuscarPorCodigoProveedor}
+                    onBuscar={handleBuscarProductos}
+                    onLimpiar={handleLimpiarBusquedaProductos}
                     paginacionControlada={true}
                     paginaActual={pagina}
                     onPageChange={setPagina}

--- a/ferredesk_v0/frontend/src/components/Productos/ProductosTable.js
+++ b/ferredesk_v0/frontend/src/components/Productos/ProductosTable.js
@@ -175,6 +175,9 @@ export default function ProductosTable({
   setSearchProductos,
   buscarPorCodigoProveedor = false,
   setBuscarPorCodigoProveedor = () => { },
+  onBuscar = () => { },
+  onLimpiar = () => { },
+  consultaEjecutada = false,
   paginacionControlada = false,
   paginaActual,
   onPageChange,
@@ -239,77 +242,7 @@ export default function ProductosTable({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Filtros de familias */}
-      <div className="mb-2 flex items-center gap-2 flex-wrap">
-        <div>
-          <label className="block text-xs text-slate-600">Familia</label>
-          <select
-            value={fam1Filtro}
-            onChange={(e) => setFam1Filtro(e.target.value)}
-            className="pl-2 pr-2 py-1 rounded-lg border border-slate-300 bg-slate-50 text-slate-800 text-sm"
-          >
-            <option value="">Todas</option>
-            {familias
-              .filter((f) => f.nivel === "1")
-              .map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.deno}
-                </option>
-              ))}
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-slate-600">Subfamilia</label>
-          <select
-            value={fam2Filtro}
-            onChange={(e) => setFam2Filtro(e.target.value)}
-            className="pl-2 pr-2 py-1 rounded-lg border border-slate-300 bg-slate-50 text-slate-800 text-sm"
-          >
-            <option value="">Todas</option>
-            {familias
-              .filter((f) => f.nivel === "2")
-              .map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.deno}
-                </option>
-              ))}
-          </select>
-        </div>
-        <div>
-          <label className="block text-xs text-slate-600">Sub-sub</label>
-          <select
-            value={fam3Filtro}
-            onChange={(e) => setFam3Filtro(e.target.value)}
-            className="pl-2 pr-2 py-1 rounded-lg border border-slate-300 bg-slate-50 text-slate-800 text-sm"
-          >
-            <option value="">Todas</option>
-            {familias
-              .filter((f) => f.nivel === "3")
-              .map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.deno}
-                </option>
-              ))}
-          </select>
-        </div>
-      </div>
-
       <div className="flex-1">
-        {/* Toggle de modo de búsqueda por código de proveedor */}
-        <div className="mb-2 flex items-center">
-          <label className="flex items-center gap-1.5 text-sm text-slate-600 cursor-pointer select-none hover:text-orange-600 transition-colors">
-            <input
-              type="checkbox"
-              checked={buscarPorCodigoProveedor}
-              onChange={(e) => {
-                setBuscarPorCodigoProveedor(e.target.checked)
-                setSearchProductos('') // Limpiar búsqueda al cambiar modo para evitar resultados cruzados
-              }}
-              className="rounded border-slate-300 text-orange-600 focus:ring-orange-500"
-            />
-            Buscar por código de proveedor
-          </label>
-        </div>
         {/* Definición de columnas */}
         {(() => {
           const columnas = [
@@ -369,6 +302,8 @@ export default function ProductosTable({
               datos={productos}
               valorBusqueda={searchProductos}
               onCambioBusqueda={setSearchProductos}
+              onBuscar={onBuscar}
+              onLimpiar={onLimpiar}
               mostrarBuscador={true}
               placeholderBuscador={buscarPorCodigoProveedor ? "Buscar por código de proveedor..." : "Buscar en tabla..."}
               mostrarOrdenamiento={true}
@@ -382,6 +317,8 @@ export default function ProductosTable({
               onOrdenamientoChange={onOrdenamientoChange}
               ordenamientoControlado={ordenamientoControlado}
               cargando={cargando}
+              mensajeVacio={consultaEjecutada ? "No se encontraron resultados" : "Sin consulta ejecutada"}
+              subtituloVacio={consultaEjecutada ? "" : "Usá los filtros y presioná Buscar para consultar productos."}
               renderFila={(p, idxVis, idxInicio) => {
                 const indiceGlobal = idxInicio + idxVis
 

--- a/ferredesk_v0/frontend/src/components/Productos/StockForm.js
+++ b/ferredesk_v0/frontend/src/components/Productos/StockForm.js
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState, useEffect, useRef, useCallback } from "react"
-import { useStockProveAPI } from "../../utils/useStockProveAPI"
 import { useAlicuotasIVAAPI } from "../../utils/useAlicuotasIVAAPI"
 import { useFerreteriaAPI } from "../../utils/useFerreteriaAPI"
 import useDetectorDenominaciones from "../../utils/useDetectorDenominaciones"
@@ -64,11 +63,8 @@ const StockForm = ({ stock, onSave, onCancel, proveedores, familias, modo, tabKe
   const refContenedorDenominacion = useRef(null)
   const referenciaCampoBusqueda = useRef(null)
 
-  // APIs existentes
-  const isEdicion = !!stock?.id
-  // Evitar fetch global de stockprove en edición: solo en modo "nuevo" usamos el hook
-  const stockProveAPI = useStockProveAPI()
-  const stockProve = isEdicion ? [] : stockProveAPI.stockProve
+  // Las relaciones stock/proveedor se resuelven desde el detalle cargado o el estado local del form.
+  const stockProve = []
   const { alicuotas } = useAlicuotasIVAAPI()
 
   // Hook para obtener la configuración de la ferretería

--- a/ferredesk_v0/frontend/src/components/Tabla.js
+++ b/ferredesk_v0/frontend/src/components/Tabla.js
@@ -49,6 +49,8 @@ const Tabla = ({
   datos = [],
   valorBusqueda = "",
   onCambioBusqueda = () => { },
+  onBuscar = null,
+  onLimpiar = null,
   filasPorPaginaInicial = 10,
   opcionesFilasPorPagina = [10, 20, 30, 40, 50],
   paginadorVisible = true,
@@ -129,15 +131,39 @@ const Tabla = ({
           <div className="flex items-center justify-between gap-4">
             {/* Buscador */}
             {mostrarBuscador && (
-              <div className="relative flex-1 max-w-md">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
-                <input
-                  type="text"
-                  placeholder={placeholderBuscador}
-                  className="pl-10 pr-4 py-2.5 w-full rounded-lg border border-slate-200 bg-white/80 text-slate-800 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-orange-500/40 focus:border-orange-500 transition-all duration-200 text-sm"
-                  value={valorBusqueda}
-                  onChange={(e) => onCambioBusqueda(e.target.value)}
-                />
+              <div className="flex items-center gap-2 flex-1 max-w-xl">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+                  <input
+                    type="text"
+                    placeholder={placeholderBuscador}
+                    className="pl-10 pr-4 py-2.5 w-full rounded-lg border border-slate-200 bg-white/80 text-slate-800 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-orange-500/40 focus:border-orange-500 transition-all duration-200 text-sm"
+                    value={valorBusqueda}
+                    onChange={(e) => onCambioBusqueda(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && typeof onBuscar === "function") {
+                        e.preventDefault()
+                        onBuscar()
+                      }
+                    }}
+                  />
+                </div>
+                {typeof onBuscar === "function" && (
+                  <button
+                    onClick={onBuscar}
+                    className="px-4 py-2.5 bg-orange-600 hover:bg-orange-700 active:bg-orange-800 text-white font-medium rounded-lg text-sm transition-colors duration-150 shadow-sm whitespace-nowrap"
+                  >
+                    Buscar
+                  </button>
+                )}
+                {typeof onLimpiar === "function" && (
+                  <button
+                    onClick={onLimpiar}
+                    className="px-4 py-2.5 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 text-slate-700 font-medium rounded-lg border border-slate-200 text-sm transition-colors duration-150 whitespace-nowrap"
+                  >
+                    Limpiar
+                  </button>
+                )}
               </div>
             )}
 
@@ -239,7 +265,7 @@ const Tabla = ({
                         <Search className="w-5 h-5 text-slate-400" />
                       </div>
                       <p className="text-sm font-medium">No se encontraron resultados</p>
-                      {valorBusqueda && <p className="text-xs text-slate-400">Intenta con otros términos de búsqueda</p>}
+                      {valorBusqueda && <p className="text-xs text-slate-400"></p>}
                     </div>
                   ) : (
                     <div className="flex flex-col items-center gap-2">

--- a/ferredesk_v0/frontend/src/hooks/usePaginacionAPI.js
+++ b/ferredesk_v0/frontend/src/hooks/usePaginacionAPI.js
@@ -69,6 +69,7 @@ export function usePaginacionAPI(claveCacheBase, urlBase, filtros = {}, pagina =
   const { data, isLoading, isFetching, error } = useQuery({
     queryKey: claveQuery,
     queryFn: () => clienteAPI(url),
+    enabled: opciones.enabled ?? true,
     ...withQueryProfile("warmCatalog", {
       // Mantener datos anteriores mientras llegan los nuevos (evita el parpadeo al cambiar de página)
       placeholderData: (datosAnteriores) => datosAnteriores,

--- a/ferredesk_v0/frontend/src/utils/consultaPersistida.js
+++ b/ferredesk_v0/frontend/src/utils/consultaPersistida.js
@@ -1,0 +1,25 @@
+export function leerConsultaPersistida(clave, fallback = null) {
+  try {
+    const raw = localStorage.getItem(clave)
+    if (!raw) return fallback
+    return JSON.parse(raw)
+  } catch (_) {
+    return fallback
+  }
+}
+
+export function guardarConsultaPersistida(clave, valor) {
+  try {
+    localStorage.setItem(clave, JSON.stringify(valor))
+  } catch (_) {
+    // noop
+  }
+}
+
+export function limpiarConsultaPersistida(clave) {
+  try {
+    localStorage.removeItem(clave)
+  } catch (_) {
+    // noop
+  }
+}

--- a/ferredesk_v0/frontend/src/utils/consultaPersistida.test.js
+++ b/ferredesk_v0/frontend/src/utils/consultaPersistida.test.js
@@ -1,0 +1,39 @@
+import {
+  guardarConsultaPersistida,
+  leerConsultaPersistida,
+  limpiarConsultaPersistida,
+} from "./consultaPersistida"
+
+describe("consultaPersistida", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  test("guarda y lee valores serializados", () => {
+    const valor = {
+      search: "martillo",
+      pagina: 3,
+      filtros: { activo: true },
+    }
+
+    guardarConsultaPersistida("productosConsultaPersistida", valor)
+
+    expect(leerConsultaPersistida("productosConsultaPersistida", null)).toEqual(valor)
+  })
+
+  test("devuelve fallback si no existe valor o el json es invalido", () => {
+    expect(leerConsultaPersistida("clave-inexistente", { vacio: true })).toEqual({ vacio: true })
+
+    localStorage.setItem("clave-rota", "{json invalido")
+
+    expect(leerConsultaPersistida("clave-rota", "fallback")).toBe("fallback")
+  })
+
+  test("elimina la clave persistida", () => {
+    guardarConsultaPersistida("clientesConsultaPersistida", { pagina: 1 })
+
+    limpiarConsultaPersistida("clientesConsultaPersistida")
+
+    expect(localStorage.getItem("clientesConsultaPersistida")).toBeNull()
+  })
+})

--- a/ferredesk_v0/frontend/src/utils/useClientesAPI.js
+++ b/ferredesk_v0/frontend/src/utils/useClientesAPI.js
@@ -3,7 +3,7 @@ import { clienteAPI } from './clienteAPI';
 
 export function useClientesAPI(filtrosIniciales = {}, opciones = { autoFetch: true }) {
   const [clientes, setClientes] = useState([]);
-  const [loading, setLoading] = useState(!opciones.autoFetch);
+  const [loading, setLoading] = useState(opciones.autoFetch === true);
   const [error, setError] = useState(null);
   const [total, setTotal] = useState(0);
   const lastQueryKeyRef = useRef('');

--- a/ferredesk_v0/frontend/src/utils/useFamiliasAPI.js
+++ b/ferredesk_v0/frontend/src/utils/useFamiliasAPI.js
@@ -31,10 +31,17 @@ export function useFamiliasAPI() {
         credentials: 'include',
         body: JSON.stringify(familia)
       });
-      if (!res.ok) throw new Error('Error al crear familia');
+      if (!res.ok) {
+        let errData = {};
+        try { errData = await res.json(); } catch(e){}
+        const msg = errData.detail || (errData.non_field_errors && errData.non_field_errors[0]) || (Object.keys(errData).length > 0 ? JSON.stringify(errData) : 'Error al crear familia');
+        throw new Error(msg);
+      }
       await fetchFamilias();
+      return { success: true };
     } catch (err) {
       setError(err.message);
+      return { error: err.message };
     }
   };
 
@@ -47,10 +54,17 @@ export function useFamiliasAPI() {
         credentials: 'include',
         body: JSON.stringify(updated)
       });
-      if (!res.ok) throw new Error('Error al editar familia');
+      if (!res.ok) {
+        let errData = {};
+        try { errData = await res.json(); } catch(e){}
+        const msg = errData.detail || (errData.non_field_errors && errData.non_field_errors[0]) || (Object.keys(errData).length > 0 ? JSON.stringify(errData) : 'Error al editar familia');
+        throw new Error(msg);
+      }
       await fetchFamilias();
+      return { success: true };
     } catch (err) {
       setError(err.message);
+      return { error: err.message };
     }
   };
 

--- a/ferredesk_v0/frontend/src/utils/useStockBajoAPI.js
+++ b/ferredesk_v0/frontend/src/utils/useStockBajoAPI.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { fechaHoyLocal } from './fechas';
 
 export const useStockBajoAPI = () => {
@@ -7,12 +7,23 @@ export const useStockBajoAPI = () => {
   const [error, setError] = useState(null);
   const [totalProductos, setTotalProductos] = useState(0);
 
-  const obtenerProductosStockBajo = async () => {
+  const construirQuery = (parametros = {}) => {
+    const params = new URLSearchParams()
+    Object.entries(parametros).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        params.append(key, String(value))
+      }
+    })
+    const query = params.toString()
+    return query ? `?${query}` : ''
+  }
+
+  const obtenerProductosStockBajo = async (parametros = {}) => {
     setLoading(true);
     setError(null);
     
     try {
-      const response = await fetch('/api/informes/stock-bajo/', {
+      const response = await fetch(`/api/informes/stock-bajo/${construirQuery(parametros)}`, {
         credentials: 'include'
       });
       
@@ -21,13 +32,9 @@ export const useStockBajoAPI = () => {
       }
       
       const data = await response.json();
-      
-      if (data.status === 'success') {
-        setProductos(data.data);
-        setTotalProductos(data.total_productos);
-      } else {
-        throw new Error(data.message || 'Error en la respuesta del servidor');
-      }
+      const lista = Array.isArray(data) ? data : (data.results || [])
+      setProductos(lista);
+      setTotalProductos(typeof data.count === 'number' ? data.count : lista.length);
     } catch (err) {
       setError(err.message);
       setProductos([]);
@@ -37,9 +44,9 @@ export const useStockBajoAPI = () => {
     }
   };
 
-  const generarPDF = async () => {
+  const generarPDF = async (parametros = {}) => {
     try {
-      const response = await fetch('/api/informes/stock-bajo/pdf/', {
+      const response = await fetch(`/api/informes/stock-bajo/pdf/${construirQuery(parametros)}`, {
         credentials: 'include'
       });
       
@@ -65,9 +72,11 @@ export const useStockBajoAPI = () => {
     }
   };
 
-  useEffect(() => {
-    obtenerProductosStockBajo();
-  }, []);
+  const limpiarResultados = () => {
+    setProductos([])
+    setTotalProductos(0)
+    setError(null)
+  }
 
   return {
     productos,
@@ -75,6 +84,7 @@ export const useStockBajoAPI = () => {
     error,
     totalProductos,
     obtenerProductosStockBajo,
-    generarPDF
+    generarPDF,
+    limpiarResultados
   };
 }; 

--- a/ferredesk_v0/frontend/src/utils/useStockBajoAPI.test.js
+++ b/ferredesk_v0/frontend/src/utils/useStockBajoAPI.test.js
@@ -1,0 +1,98 @@
+import React, { act } from "react"
+import { createRoot } from "react-dom/client"
+
+const { useStockBajoAPI } = require("./useStockBajoAPI")
+
+function HookHarness({ onReady }) {
+  const api = useStockBajoAPI()
+
+  React.useEffect(() => {
+    onReady(api)
+  }, [api, onReady])
+
+  return null
+}
+
+describe("useStockBajoAPI", () => {
+  let container
+  let root
+  let api
+
+  beforeEach(async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    global.fetch = jest.fn()
+
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root.render(<HookHarness onReady={(value) => { api = value }} />)
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+    jest.resetAllMocks()
+  })
+
+  test("no dispara la consulta automaticamente al montar", () => {
+    expect(global.fetch).not.toHaveBeenCalled()
+    expect(api.productos).toEqual([])
+    expect(api.totalProductos).toBe(0)
+    expect(api.loading).toBe(false)
+  })
+
+  test("obtiene productos y permite limpiar resultados", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        count: 1,
+        results: [
+          {
+            codigo_venta: "P-100",
+            denominacion: "Pinza",
+            stock_total: 1,
+          },
+        ],
+      }),
+    })
+
+    await act(async () => {
+      await api.obtenerProductosStockBajo({ search: "pinza", page: 2, limit: 20 })
+    })
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/informes/stock-bajo/?search=pinza&page=2&limit=20", {
+      credentials: "include",
+    })
+    expect(api.productos).toHaveLength(1)
+    expect(api.totalProductos).toBe(1)
+    expect(api.error).toBe(null)
+
+    await act(async () => {
+      api.limpiarResultados()
+    })
+
+    expect(api.productos).toEqual([])
+    expect(api.totalProductos).toBe(0)
+    expect(api.error).toBe(null)
+  })
+
+  test("resetea resultados cuando la consulta falla", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+    })
+
+    await act(async () => {
+      await api.obtenerProductosStockBajo()
+    })
+
+    expect(api.productos).toEqual([])
+    expect(api.totalProductos).toBe(0)
+    expect(api.error).toBe("Error al obtener datos de stock bajo")
+    expect(api.loading).toBe(false)
+  })
+})


### PR DESCRIPTION
- frontend(Clientes): Fix perpetual loading state in `useClientesAPI.js` when auto-fetch is disabled. Update `ClientesManager.js` to use the `search` param for OR-logic backend filtering. Integrate `consultaPersistida` to maintain search context across navigation.
- frontend(Productos): Integrate `consultaPersistida` in `ProductosManager.js` to persist search terms across navigation.
- frontend(UI): Resolve React `validateDOMNesting` warning in `AccionesMenu.js` by replacing nested `<button>` wrappers with `<div>`.
- frontend(Familias): Fix silent failures in `FamiliasModal.js` by awaiting API responses and explicitly alerting backend errors surfaced by `useFamiliasAPI.js`.
- backend(Productos): Remove aggressive 12-hour `cache_page` decorator from `FamiliaViewSet` in `views.py` to allow real-time table updates after ABM operations.