### PR TITLE
fix(caja): resolver doble conteo y bug de agrupación ORM en cálculo d…

### DIFF
--- a/ferredesk_v0/backend/ferreapps/caja/services/control_fondos.py
+++ b/ferredesk_v0/backend/ferreapps/caja/services/control_fondos.py
@@ -69,67 +69,23 @@ def resolve_recent_activity_range(*, fecha_desde=None, fecha_hasta=None):
 
 
 def _calcular_saldo_teorico_sesion(sesion):
-    pagos_efectivo = _decimal_or_zero(
-        PagoVenta.objects.filter(
-            Q(venta__sesion_caja=sesion) | Q(recibo__sesion_caja=sesion),
-            metodo_pago__afecta_arqueo=True,
-            es_vuelto=False,
-        )
-        .exclude(venta__ven_estado="AN")
-        .exclude(recibo__rec_estado=Recibo.ESTADO_ANULADO)
-        .aggregate(total=Sum("monto"))["total"]
-    )
-
-    vueltos = _decimal_or_zero(
-        PagoVenta.objects.filter(
-            venta__sesion_caja=sesion,
-            metodo_pago__afecta_arqueo=True,
-            es_vuelto=True,
-        )
-        .exclude(venta__ven_estado="AN")
-        .aggregate(total=Sum("monto"))["total"]
-    )
-
     ingresos = _decimal_or_zero(
         sesion.movimientos.filter(tipo=TIPO_MOVIMIENTO_ENTRADA).aggregate(total=Sum("monto"))["total"]
     )
     egresos = _decimal_or_zero(
         sesion.movimientos.filter(tipo=TIPO_MOVIMIENTO_SALIDA).aggregate(total=Sum("monto"))["total"]
     )
-    return sesion.saldo_inicial + pagos_efectivo - vueltos + ingresos - egresos
+    return sesion.saldo_inicial + ingresos - egresos
 
 
 def _calcular_caja_actual():
     decimal_field = DecimalField(max_digits=15, decimal_places=2)
-    pagos_efectivo_subquery = (
-        PagoVenta.objects.filter(
-            Q(venta__sesion_caja=OuterRef("pk")) | Q(recibo__sesion_caja=OuterRef("pk")),
-            metodo_pago__afecta_arqueo=True,
-            es_vuelto=False,
-        )
-        .exclude(venta__ven_estado="AN")
-        .exclude(recibo__rec_estado=Recibo.ESTADO_ANULADO)
-        .values()
-        .annotate(total=Sum("monto"))
-        .values("total")[:1]
-    )
-    vueltos_subquery = (
-        PagoVenta.objects.filter(
-            venta__sesion_caja=OuterRef("pk"),
-            metodo_pago__afecta_arqueo=True,
-            es_vuelto=True,
-        )
-        .exclude(venta__ven_estado="AN")
-        .values()
-        .annotate(total=Sum("monto"))
-        .values("total")[:1]
-    )
     ingresos_subquery = (
         MovimientoCaja.objects.filter(
             sesion_caja=OuterRef("pk"),
             tipo=TIPO_MOVIMIENTO_ENTRADA,
         )
-        .values()
+        .values("sesion_caja")
         .annotate(total=Sum("monto"))
         .values("total")[:1]
     )
@@ -138,20 +94,12 @@ def _calcular_caja_actual():
             sesion_caja=OuterRef("pk"),
             tipo=TIPO_MOVIMIENTO_SALIDA,
         )
-        .values()
+        .values("sesion_caja")
         .annotate(total=Sum("monto"))
         .values("total")[:1]
     )
 
     sesiones = SesionCaja.objects.filter(estado=ESTADO_CAJA_ABIERTA).annotate(
-        pagos_efectivo=Coalesce(
-            Subquery(pagos_efectivo_subquery, output_field=decimal_field),
-            Value(ZERO, output_field=decimal_field),
-        ),
-        vueltos=Coalesce(
-            Subquery(vueltos_subquery, output_field=decimal_field),
-            Value(ZERO, output_field=decimal_field),
-        ),
         ingresos=Coalesce(
             Subquery(ingresos_subquery, output_field=decimal_field),
             Value(ZERO, output_field=decimal_field),
@@ -164,7 +112,7 @@ def _calcular_caja_actual():
     total = _decimal_or_zero(
         sesiones.aggregate(
             total=Sum(
-                F("saldo_inicial") + F("pagos_efectivo") - F("vueltos") + F("ingresos") - F("egresos"),
+                F("saldo_inicial") + F("ingresos") - F("egresos"),
                 output_field=decimal_field,
             )
         )["total"]

--- a/ferredesk_v0/backend/ferreapps/caja/tests/test_control_fondos_service.py
+++ b/ferredesk_v0/backend/ferreapps/caja/tests/test_control_fondos_service.py
@@ -222,11 +222,25 @@ class ControlFondosServiceTests(CajaTenantTestCase, CajaTestMixin):
             monto=Decimal("200.00"),
             es_vuelto=False,
         )
+        MovimientoCaja.objects.create(
+            sesion_caja=sesion_abierta,
+            usuario=self.usuario,
+            tipo=TIPO_MOVIMIENTO_ENTRADA,
+            monto=Decimal("200.00"),
+            descripcion="Pago venta",
+        )
         PagoVenta.objects.create(
             venta=venta_abierta,
             metodo_pago=metodo_efectivo,
             monto=Decimal("30.00"),
             es_vuelto=True,
+        )
+        MovimientoCaja.objects.create(
+            sesion_caja=sesion_abierta,
+            usuario=self.usuario,
+            tipo=TIPO_MOVIMIENTO_SALIDA,
+            monto=Decimal("30.00"),
+            descripcion="Vuelto venta",
         )
         MovimientoCaja.objects.create(
             sesion_caja=sesion_abierta,
@@ -262,6 +276,36 @@ class ControlFondosServiceTests(CajaTenantTestCase, CajaTestMixin):
         self.assertEqual(kpis["caja"]["monto"], "1200.00")
         self.assertEqual(kpis["disponible_hoy"]["monto"], "1200.00")
         self.assertTrue(payload["seniales"]["hay_caja_abierta"])
+
+    def test_no_doble_conteo_al_registrar_venta(self):
+        from ferreapps.caja.utils import registrar_pagos_venta, registrar_vuelto
+
+        metodo_efectivo, _ = MetodoPago.objects.get_or_create(
+            codigo=CODIGO_EFECTIVO,
+            defaults={"nombre": "Efectivo", "afecta_arqueo": True, "activo": True},
+        )
+
+        sesion_abierta = self.crear_sesion_caja(self.usuario, saldo_inicial=Decimal("1000.00"))
+        venta_abierta = self._crear_venta(2005, sesion_caja=sesion_abierta)
+        
+        # Simular flujo real que crea PagoVenta y MovimientoCaja
+        registrar_pagos_venta(
+            venta=venta_abierta,
+            sesion_caja=sesion_abierta,
+            pagos=[{'metodo_pago_id': metodo_efectivo.id, 'monto': Decimal("200.00")}]
+        )
+        registrar_vuelto(
+            venta=venta_abierta,
+            sesion_caja=sesion_abierta,
+            monto_vuelto=Decimal("30.00"),
+            metodo_pago_id=metodo_efectivo.id
+        )
+
+        payload = build_control_fondos_payload()
+        kpis = payload["resumen_actual"]["kpis"]
+
+        # El saldo teórico (1000 + 200 - 30 = 1170) no debería estar duplicado.
+        self.assertEqual(kpis["caja"]["monto"], "1170.00")
 
     def test_control_fondos_reutiliza_cache_corta_por_tenant_y_parametros(self):
         with patch(

--- a/ferredesk_v0/backend/ferreapps/caja/views.py
+++ b/ferredesk_v0/backend/ferreapps/caja/views.py
@@ -231,46 +231,19 @@ class SesionCajaViewSet(viewsets.ModelViewSet):
         
         Fórmula:
         Saldo = Saldo Inicial 
-              + Pagos en efectivo (que afectan arqueo)
-              - Vueltos en efectivo
-              + Ingresos manuales
-              - Egresos manuales
+              + Ingresos manuales y automáticos
+              - Egresos manuales y automáticos
         """
         saldo = sesion.saldo_inicial
         
-        # Sumar pagos que afectan arqueo (efectivo)
-        # Consideramos tanto pagos de Ventas como de Recibos vinculados a esta sesión
-        pagos_efectivo = PagoVenta.objects.filter(
-            Q(venta__sesion_caja=sesion) | Q(recibo__sesion_caja=sesion),
-            metodo_pago__afecta_arqueo=True,
-            es_vuelto=False
-        ).exclude(
-            venta__ven_estado='AN'
-        ).exclude(
-            recibo__rec_estado='N'
-        ).aggregate(total=Sum('monto'))['total'] or Decimal('0.00')
-        
-        saldo += pagos_efectivo
-        
-        # Restar vueltos dados (solo aplica a ventas en este ERP)
-        vueltos = PagoVenta.objects.filter(
-            venta__sesion_caja=sesion,
-            metodo_pago__afecta_arqueo=True,
-            es_vuelto=True,
-        ).exclude(
-            venta__ven_estado='AN'
-        ).aggregate(total=Sum('monto'))['total'] or Decimal('0.00')
-        
-        saldo -= vueltos
-        
-        # Sumar ingresos manuales
+        # Sumar ingresos manuales y automáticos
         ingresos = sesion.movimientos.filter(
             tipo=TIPO_MOVIMIENTO_ENTRADA
         ).aggregate(total=Sum('monto'))['total'] or Decimal('0.00')
         
         saldo += ingresos
         
-        # Restar egresos manuales
+        # Restar egresos manuales y automáticos
         egresos = sesion.movimientos.filter(
             tipo=TIPO_MOVIMIENTO_SALIDA
         ).aggregate(total=Sum('monto'))['total'] or Decimal('0.00')

--- a/ferredesk_v0/frontend/src/components/Caja/CajaMovimientos.js
+++ b/ferredesk_v0/frontend/src/components/Caja/CajaMovimientos.js
@@ -30,7 +30,7 @@ const CajaMovimientos = ({ movimientos, theme }) => {
   return (
     <div>
       <h3 className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 mb-1.5">
-        Movimientos Manuales
+        Libro de Caja
       </h3>
 
       {movimientosOrdenados.length === 0 ? (


### PR DESCRIPTION
…e saldos

- Corrige bug de Django ORM donde un `.values()` vacío en subconsultas provocaba una agrupación incorrecta (GROUP BY) y rompía la suma de los KPIs en el dashboard de control de fondos.
- Elimina la tabla `PagoVenta` de las fórmulas de saldo teórico, utilizando únicamente `MovimientoCaja` como fuente de verdad. Esto soluciona la duplicación de ingresos/egresos en efectivo.
- Renombra el título del componente `CajaMovimientos` en el frontend a "Libro de Caja" para reflejar con mayor precisión que lista movimientos tanto manuales como automáticos.
- Añade y actualiza tests en `test_control_fondos_service.py` para simular el flujo real de cobro y prevenir regresiones de doble conteo.